### PR TITLE
Update JSHint

### DIFF
--- a/templates/uber/content/jshint.json
+++ b/templates/uber/content/jshint.json
@@ -17,7 +17,6 @@
     "unused": true,
     "strict": false,
     "trailing": true,
-    "node": true,
     "noempty": true,
     "maxdepth": 4,
     "maxparams": 4,
@@ -27,6 +26,13 @@
         "setTimeout": true,
         "clearTimeout": true,
         "setInterval": true,
-        "clearInterval": true
+        "clearInterval": true,
+        "require": false,
+        "module": false,
+        "exports": true,
+        "global": false,
+        "process": true,
+        "__dirname": false,
+        "__filename": false
     }
 }


### PR DESCRIPTION
The node defaults are poorly defined.

See https://github.com/jshint/jshint/pull/1426

Basically globals should be writable to enable things like

`var setTimeout = require('timers').setTimeout`
