### PR TITLE
change default from mocha to tape

### DIFF
--- a/templates/uber/content/package.json
+++ b/templates/uber/content/package.json
@@ -14,15 +14,16 @@
   "dependencies": {
   },
   "devDependencies": {
-    "mocha": "~1.17.1",
+    "tape": "^2.10.2",
     "jshint": "2.4.2",
     "istanbul": "~0.2.4",
+    "tap-spec": "~0.1.4",
     "pre-commit": "0.0.4"
   },
   "scripts": {
-    "test": "npm run jshint && NODE_ENV=test mocha --reporter spec",
+    "test": "npm run jshint && istanbul --print=none cover test/index.js | tspec && istanbul report text",
     "jshint": "jshint --verbose --exclude-path .gitignore .",
-    "cover": "istanbul cover --report none --print detail _mocha",
+    "cover": "istanbul cover --report none --print detail test/index.js",
     "view-cover": "istanbul report html && open ./coverage/index.html"
   },
   "engine": {

--- a/templates/uber/content/test/index.js
+++ b/templates/uber/content/test/index.js
@@ -1,9 +1,8 @@
-var test = require('mocha').it;
-var assert = require('assert');
+var test = require('tape');
 
 var {{projectName}} = require('../index.js');
 
-test('{{projectName}} is a function', function (end) {
+test('{{projectName}} is a function', function (assert) {
     assert.strictEqual(typeof {{projectName}}, 'function');
-    end();
+    assert.end();
 });


### PR DESCRIPTION
Tape is a nicer default then mocha 

The following now use tape:
- rt/tia
- rt/cerebro-client
- uber/build-changelog

Reasons for tape:
- can run programs with `node`
- supports TAP out of the box
- works cleanly in browser + node
- has low implementation complexity
- no globals
- has `test.only()` feature to run a single block
- has modular reporter with `tap-spec`
- well maintained (has zero open issues)

cc @jcorbin @sh1mmer 
