### PR TITLE
Use .jshintignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,7 @@ Template.prototype.create = function() {
             }
         }
     });
+    fs.symlinkSync('.gitignore', '.jshintignore');
     self.logger.log();
 };
 

--- a/templates/uber/content/package.json
+++ b/templates/uber/content/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "test": "npm run jshint && istanbul --print=none cover test/index.js | tspec && istanbul report text",
-    "jshint": "jshint --verbose --exclude-path .gitignore .",
+    "jshint": "jshint --verbose .",
     "cover": "istanbul cover --report none --print detail test/index.js",
     "view-cover": "istanbul report html && open ./coverage/index.html"
   },


### PR DESCRIPTION
So we can just use .jshintignore, and then running jshint outside of npm (like say from editor integrators) Gets It Right Too (tm).

I briefly considered adding some generic symlink support along side your `directories` vs not (aka files, because like that's all there is right?) but decided not to.
