### PR TITLE
pass all options into template

### DIFF
--- a/bin/ngen.js
+++ b/bin/ngen.js
@@ -27,23 +27,21 @@ function printHelp(opts) {
 
 function main(opts) {
     // parse arguments
-    if (opts.h || opts.help || opts._.length === 0) {
+    if (opts.h || opts.help) {
         return printHelp(opts);
     }
 
-    var template = opts.t || opts.template || 'uber';
-    var templates = opts.d || opts.directory ||
+    opts.template = opts.t || opts.template || 'uber';
+    opts.templates = opts.d || opts.directory ||
         path.join(__dirname, '..', 'templates');
-    var dest = opts.name || opts._[0];
-    var description = opts.description || opts._[1];
+    opts.name = opts.name || opts._[0];
+    opts.description = opts.description || opts._[1];
+
+    opts.logger = console;
 
     // create template
-    var tmpl = new Template(template, {
-        templates: templates,
-        description: description,
-        logger: console
-    });
-    tmpl.init(dest, function (err) {
+    var tmpl = new Template(opts.template, opts);
+    tmpl.init(opts.name, function (err) {
         if (err) {
             console.error(err.message);
             return process.exit(1);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var fs = require('fs');
 var join = require('path').join;
 var prompt = require('promptly').prompt;
 var chalk = require('chalk');
+var extend = require('xtend');
 
 function noop() {}
 
@@ -26,9 +27,9 @@ function Template(name, opts) {
     this.path = join(this.templates, name);
     this.contentPath = this.path + '/content';
     this.mod = require(this.path);
-    this.values = {
+    this.values = extend(opts, {
         year: new Date().getFullYear()
-    };
+    });
     this.directories = {};
 }
 
@@ -45,7 +46,6 @@ Template.prototype.init = function(dest, callback) {
     var keys = Object.keys(vars);
 
     self.values.project = dest;
-    self.values.description = self.description;
     self.dest = dest;
     // print new line for pretties.
     self.logger.log();

--- a/package.json
+++ b/package.json
@@ -22,11 +22,12 @@
   ],
   "dependencies": {
     "camelize": "~0.1.2",
-    "promptly": "~0.2.0",
     "chalk": "~0.4.0",
     "minimist": "0.0.8",
     "msee": "~0.1.1",
-    "string-template": "~0.1.3"
+    "promptly": "~0.2.0",
+    "string-template": "~0.1.3",
+    "xtend": "^2.2.0"
   },
   "licenses": [
     {
@@ -42,7 +43,7 @@
     "uber-ngen": "./bin/ngen.js"
   },
   "devDependencies": {
-    "pre-commit": "0.0.4",
-    "jshint": "~2.4.4"
+    "jshint": "~2.4.4",
+    "pre-commit": "0.0.5"
   }
 }


### PR DESCRIPTION
cc @sh1mmer @jcorbin 

This change allows passing a `ns` or `namespace` key like `'rt'` or `'os'` into the template without having to specify it explicitly at the prompt.
