### PR TITLE
update defaults to include a faster pre-commit hook

### DIFF
--- a/templates/uber/content/package.json
+++ b/templates/uber/content/package.json
@@ -14,25 +14,34 @@
   "dependencies": {
   },
   "devDependencies": {
-    "tape": "^2.10.2",
-    "jshint": "2.4.2",
-    "istanbul": "~0.2.4",
-    "tap-spec": "~0.1.4",
-    "pre-commit": "0.0.4"
+    "tape": "^2.12.3",
+    "jshint": "^2.5.0",
+    "istanbul": "^0.2.7",
+    "tap-spec": "^0.1.8",
+    "pre-commit": "0.0.5",
+    "run-browser": "Raynos/run-browser#v1.2.0-phantom"
   },
   "licenses": [{
     "type": "MIT",
     "url": "http://github.com/uber/{{project}}/raw/master/LICENSE"
   }],
   "scripts": {
-    "test": "npm run jshint && istanbul --print=none cover test/index.js | tspec && istanbul report text",
+    "test": "npm run jshint --silent && npm run unit-test --silent",
+    "unit-test": "NODE_ENV=test node test/index.js | tap-spec",
+    "jshint-pre-commit": "jshint --verbose $(git diff --cached --name-only | grep '\\.js$')",
     "jshint": "jshint --verbose .",
     "cover": "istanbul cover --report none --print detail test/index.js",
-    "view-cover": "istanbul report html && open ./coverage/index.html"
+    "view-cover": "istanbul report html && open ./coverage/index.html",
+    "browser": "run-browser test/index.js",
+    "phantom": "run-browser test/index.js -b"
   },
   "engine": {
     "node": ">= 0.8.x"
   },
+  "pre-commit": [
+    "jshint-pre-commit",
+    "unit-test"
+  ],
   "private": true,
   "uber-ngen-version": "{{version}}"
 }


### PR DESCRIPTION
This applies the changes from https://github.com/uber/play-doh/pull/46 here as well.
- make pre-commit faster
- add targets to run tests in browser

cc @sh1mmer @jcorbin 
