### PR TITLE
Set shadow to outer

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
     "trailing": true,
     "node": true,
     "noempty": true,
+    "shadow": "outer",
     "maxdepth": 4,
     "maxparams": 4,
     "globals": {

--- a/templates/uber/content/.jshintrc
+++ b/templates/uber/content/.jshintrc
@@ -19,6 +19,7 @@
   "trailing": true,
   "node": true,
   "noempty": true,
+  "shadow": "outer",
   "maxdepth": 4,
   "maxparams": 4,
   "globals": {


### PR DESCRIPTION
I ran into this bug 10 minutes ago

```js
if (opts.lateTimeoutLogger) {
    opts.logger = {
        fatal: function fatal(message, opts, cb) {
            // simulate a really slow logger
            setTimeout(function delay() {
                cb();
            }, opts.loggerTimeout * 2);
        }
    };
}
```

Here I set `opts.logger` to a function that has a parameter named `opts`. The function parameter of the fatal method shadows the outer `opts` and thus referencing `opts.loggerTimeout` is `undefined` which means passing `NaN` to `setTimeout` which is much fun.

jshint has a feature called `"shadow": "outer"` which is disabled by default. If you opt into this it will complain about all shadowing of variable names defined in outer scopes.

This means the above code is now a static bug and has to be refactored to `fatal(message, options, cb)` or something.

This is a great poorly documented feature. (only documented in the unit tests -.-)

cc @dfellis @sh1mmer @mlmorg @Matt-Esch 