### PR TITLE
Copy file buffers when data is unchanged after interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,8 +164,13 @@ Template.prototype.create = function() {
         } else {
             if (!fs.existsSync(out)) {
                 stat = fs.statSync(file);
-                var str = self.parse(fs.readFileSync(file, 'utf8'));
-                fs.writeFileSync(out, str, {
+                var buf = fs.readFileSync(file);
+                var str = buf.toString();
+                var parsed = self.parse(str);
+                // If the parsed content is no different than the original,
+                // write out the buffer to prevent encoding issues (e.g. images)
+                var content = str === parsed ? buf : parsed;
+                fs.writeFileSync(out, content, {
                     mode: stat.mode
                 });
                 if (written === false) {


### PR DESCRIPTION
This fixes an issue whereby images would become corrupted during the copying process because they would be improperly decoded as utf8.

Maybe it would be better to try to determine the mime type of the file instead of assessing whether any interpolation happened on the file contents...but this seemed like the simplest fix.

cc @Raynos @sh1mmer 
