### PR TITLE
dest path doesn't become package.json:name

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,9 @@ Template.prototype.init = function(dest, callback) {
     var vars = self.mod;
     var keys = Object.keys(vars);
 
-    self.values.project = path.basename(dest);
+    if (dest) {
+        self.values.project = path.basename(dest);
+    }
     self.dest = dest;
     // print new line for pretties.
     self.logger.log();


### PR DESCRIPTION
Currently, if you set a dest of `foo` then the project is written to `process.pwd() + '/foo'` and package.json:name is `foo`. However a dest of `path/to/foo` writes to the correct location but causes package.json:name to be a path as well, which is wrong.

@Raynos 

Please version bump after merging in.
