### PR TITLE
Fix exclusions.js to run after parseLocal so it receives full user input

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,13 +32,6 @@ function Template(name, opts) {
     });
     this.updateJSON = opts['update-json'];
     this.directories = {};
-    //TODO make this a bit less janky
-    try {
-        this.exclusions = require(this.path + '/exclude.js')(this.values);
-    } catch(e) {
-        if (e.code !== 'MODULE_NOT_FOUND') { throw e; }
-        this.exclusions = [];
-    }
     this.fromJson = false;
     // Allowing overriding of values to be passed in instead of gathering them from user input.
     if (Object.keys(opts.jsonValues).length && Object.keys(opts.jsonValues).length > 0) {
@@ -70,6 +63,8 @@ Template.prototype.init = function(dest, callback) {
     function parseLocal() {
         var desc;
         var key = keys.shift();
+
+        self.values.name = self.name;
 
         function done(err, value) {
             if (err) {
@@ -127,6 +122,14 @@ Template.prototype.init = function(dest, callback) {
 Template.prototype.files = function() {
     var self = this;
     var files = [];
+
+    //TODO make this a bit less janky
+    try {
+        this.exclusions = require(this.path + '/exclude.js')(this.values);
+    } catch(e) {
+        if (e.code !== 'MODULE_NOT_FOUND') { throw e; }
+        this.exclusions = [];
+    }
 
     (function readdirs(dir) {
         fs.readdirSync(dir).forEach(function(file){


### PR DESCRIPTION
This is proposed as a minor release.

This change fixes a bug where the excludes.js file would receive the `this.values` before it had be propagated by `parseLocal()`. It does not stop and use of `excludes.js` that would have worked (such as static additions to the excludes array) from still working.

cc @Raynos @alexfetisov 